### PR TITLE
Fix root render setup

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,13 +1,9 @@
 import React from "react";
-import ReactDOM from "react-dom";
-import { ChakraProvider } from "@chakra-ui/react";
-import { createRoot } from "react-dom"; // Importa createRoot desde react-dom
+import { createRoot } from "react-dom/client";
 import App from "./App";
 
 createRoot(document.getElementById("root")).render(
   <React.StrictMode>
-    <ChakraProvider>
-      <App />
-    </ChakraProvider>
+    <App />
   </React.StrictMode>
 );


### PR DESCRIPTION
## Summary
- use `createRoot` from `react-dom/client`
- remove unused `ReactDOM` import
- rely on Chakra provider in `App`

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843ef42ea948322bc1f5aaa9a8196ca