### PR TITLE
Fix classname attribute in Cart Link

### DIFF
--- a/src/components/Cart/Cart.jsx
+++ b/src/components/Cart/Cart.jsx
@@ -10,7 +10,7 @@ const Cart = () => {
     return (
       <div>
         <h1>No hay items en el carrito</h1>
-        <Link to="/" classname="Option">
+        <Link to="/" className="Option">
           Productos
         </Link>
       </div>


### PR DESCRIPTION
## Summary
- use `className` for the `Link` component in `Cart.jsx`

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843ef4481448322a9b9fa331d8c50f0