### PR TITLE
Add React Query pagination

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ This app is a small e‑commerce demo built with React. It showcases a catalog o
 
 - **Chakra UI** – provides accessible, themeable React components used throughout the interface.
 - **React Router** – handles client side routing between pages of the store.
+- **React Query** – caches product data locally and provides pagination support.
 
 Other dependencies include FontAwesome icons and Framer Motion for small animations. See `package.json` for the full list.
 
@@ -31,6 +32,10 @@ src/
 ```
 
 Components consume hooks and should avoid data fetching or direct business logic. Hooks use services to interact with APIs or mocks.
+
+## Pagination and caching
+
+`useProducts` relies on **React Query** to fetch and cache products. The current filters and page are stored in the URL so the state can be shared. Switching pages keeps the previous list while new data loads in the background.
 
 ## Service pattern
 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "react-dom": "^18.2.0",
     "react-icons": "^4.8.0",
     "react-router-dom": "^6.11.2",
-    "react-scripts": "^5.0.1"
+    "react-scripts": "^5.0.1",
+    "@tanstack/react-query": "^4.29.0"
   },
   "browserslist": {
     "production": [

--- a/src/components/ItemListContainer/ItemListContainer.jsx
+++ b/src/components/ItemListContainer/ItemListContainer.jsx
@@ -1,7 +1,6 @@
 import {
   Container,
   Heading,
-  Spinner,
   Center,
   Text,
   Box,
@@ -22,62 +21,33 @@ import useProducts from "../../hooks/useProducts";
 import ProductList from "../ProductList/ProductList";
 import ProductFilters from "../ProductFilters/ProductFilters";
 import { motion } from "framer-motion";
-import { useSearchParams } from "react-router-dom";
 import { useParams } from "react-router-dom";
 
 const MotionBox = motion(Box);
 
 const ItemListContainer = ({ greeting }) => {
   const [sortOption, setSortOption] = useState("recommended");
-  const [currentPage, setCurrentPage] = useState(1);
   const productsPerPage = 9;
   const { categoryId } = useParams();
 
-  const [searchParams, setSearchParams] = useSearchParams();
   const { isOpen, onOpen, onClose } = useDisclosure();
-
-  const parseFiltersFromParams = () => ({
-    type: searchParams.getAll("type"),
-    age: searchParams.getAll("age"),
-    theme: searchParams.getAll("theme"),
-    interests: searchParams.getAll("interests"),
-    pieces: searchParams.getAll("pieces"),
-    highlight: searchParams.getAll("highlight"),
-  });
-
-  const [filters, setFilters] = useState(parseFiltersFromParams);
-
-  useEffect(() => {
-    setFilters(parseFiltersFromParams());
-  }, [searchParams]);
-
-  useEffect(() => {
-    const params = new URLSearchParams();
-    Object.entries(filters).forEach(([key, values]) => {
-      values.forEach((val) => params.append(key, val));
-    });
-    setSearchParams(params, { replace: true });
-    setCurrentPage(1); // Reset page cuando cambian filtros
-  }, [filters, setSearchParams]);
 
   const {
     products,
-    filteredProducts,
-    paginatedProducts,
+    total,
     totalPages,
-    loading,
-  } = useProducts({
-    categoryId,
+    page,
+    setPage,
     filters,
-    sortOption,
-    currentPage,
-    productsPerPage,
-  });
+    setFilters,
+    isLoading,
+    isFetching,
+  } = useProducts({ categoryId, sortOption, productsPerPage });
 
   // Scroll to top cuando cambio filtros o sort o page
   useEffect(() => {
     window.scrollTo({ top: 200, behavior: "smooth" });
-  }, [filters, sortOption, currentPage]);
+  }, [filters, sortOption, page]);
 
   const totalFiltersApplied = Object.values(filters).reduce(
     (acc, arr) => acc + arr.length,
@@ -99,7 +69,7 @@ const ItemListContainer = ({ greeting }) => {
         </Heading>
       )}
 
-      {loading ? (
+      {isLoading ? (
         <Flex gap={6} wrap="wrap" justify="center">
           {Array.from({ length: 9 }).map((_, i) => (
             <Skeleton key={i} height="450px" width="300px" borderRadius="lg" />
@@ -122,8 +92,7 @@ const ItemListContainer = ({ greeting }) => {
             <ProductFilters
               filters={filters}
               setFilters={setFilters}
-              filteredProducts={filteredProducts}
-              products={products} // ✅ agregar esta prop aquí también (muy importante!)
+              products={products}
             />
           </Box>
 
@@ -138,8 +107,7 @@ const ItemListContainer = ({ greeting }) => {
             >
               <Flex flexDir="column">
                 <Text fontSize="lg" fontWeight="bold">
-                  Mostrando {filteredProducts.length} productos de{" "}
-                  {products.length}
+                  Mostrando {total} productos
                 </Text>
                 {totalFiltersApplied > 0 && (
                   <Text fontSize="sm" color="teal.600">
@@ -177,7 +145,7 @@ const ItemListContainer = ({ greeting }) => {
               </Flex>
             </Flex>
 
-            {paginatedProducts.length === 0 ? (
+            {products.length === 0 ? (
               <Center flexDir="column" py={20} color="gray.500">
                 <Image
                   src="https://cdn-icons-png.flaticon.com/512/192/192292.png"
@@ -193,42 +161,47 @@ const ItemListContainer = ({ greeting }) => {
             ) : (
               <>
                 <MotionBox
-                  key={JSON.stringify(filters) + sortOption + currentPage}
+                  key={JSON.stringify(filters) + sortOption + page}
                   initial={{ opacity: 0, scale: 0.95 }}
                   animate={{ opacity: 1, scale: 1 }}
                   exit={{ opacity: 0, scale: 0.95 }}
                   transition={{ duration: 0.4, ease: "easeOut" }}
                 >
-                  <ProductList products={paginatedProducts} />
+                  <ProductList products={products} />
                 </MotionBox>
+
+                {isFetching && (
+                  <Flex gap={6} wrap="wrap" justify="center" mt={4}>
+                    {Array.from({ length: productsPerPage }).map((_, i) => (
+                      <Skeleton
+                        key={i}
+                        height="450px"
+                        width="300px"
+                        borderRadius="lg"
+                      />
+                    ))}
+                  </Flex>
+                )}
 
                 {/* Paginación */}
                 <Flex justify="center" mt={8} gap={2}>
                   <Button
                     size="sm"
-                    onClick={() => setCurrentPage((p) => Math.max(p - 1, 1))}
-                    isDisabled={currentPage === 1}
+                    onClick={() => setPage((p) => Math.max(p - 1, 1))}
+                    isDisabled={page === 1}
                     aria-label="Página anterior"
                   >
                     Anterior
                   </Button>
                   <Text fontSize="sm" fontWeight="medium">
-                    Página {currentPage} / {totalPages}
+                    Página {page} / {totalPages}
                   </Text>
                   <Button
                     size="sm"
                     onClick={() =>
-                      setCurrentPage((p) =>
-                        Math.min(
-                          p + 1,
-                          totalPages
-                        )
-                      )
+                      setPage((p) => Math.min(p + 1, totalPages))
                     }
-                    isDisabled={
-                      currentPage ===
-                      totalPages
-                    }
+                    isDisabled={page === totalPages}
                     aria-label="Página siguiente"
                   >
                     Siguiente
@@ -249,8 +222,7 @@ const ItemListContainer = ({ greeting }) => {
             <ProductFilters
               filters={filters}
               setFilters={setFilters}
-              filteredProducts={filteredProducts}
-              products={products} // ✅ agregar esta prop
+              products={products}
             />
           </DrawerBody>
         </DrawerContent>

--- a/src/components/ProductFilters/ProductFilters.jsx
+++ b/src/components/ProductFilters/ProductFilters.jsx
@@ -47,7 +47,7 @@ const FILTER_CONFIG = [
   { label: "Destacados", key: "highlight", options: ["Exclusivos", "Destacados", "Edición Limitada"] },
 ];
 
-const ProductFilters = ({ filters, setFilters, filteredProducts, products }) => {
+const ProductFilters = ({ filters, setFilters, products }) => {
   const collapses = FILTER_CONFIG.map(() => useDisclosure({ defaultIsOpen: true }));
 
   const [showMoreMap, setShowMoreMap] = useState({});

--- a/src/components/Service/asyncMock.js
+++ b/src/components/Service/asyncMock.js
@@ -323,6 +323,73 @@ export const getProductsByFilters = (filters) => {
   });
 };
 
+export const getProductsPaginated = ({
+  page = 1,
+  limit = 9,
+  categoryId,
+  filters = {},
+  sortOption,
+}) => {
+  return new Promise((resolve) => {
+    setTimeout(() => {
+      let result = [...products];
+
+      if (categoryId) {
+        result = result.filter(
+          (p) => p.category.toLowerCase() === categoryId.toLowerCase()
+        );
+      }
+
+      const matches = (prod, key, values) => {
+        if (!values?.length) return true;
+        switch (key) {
+          case "type":
+            return values.includes(prod.type);
+          case "age":
+            return values.includes(prod.age);
+          case "theme":
+            return values.includes(prod.theme);
+          case "interests":
+            return values.some((i) => prod.interests.includes(i));
+          case "pieces":
+            return values.includes(prod.pieces);
+          case "highlight":
+            return values.includes(prod.highlight);
+          default:
+            return true;
+        }
+      };
+
+      result = result.filter((prod) =>
+        Object.entries(filters).every(([k, v]) => matches(prod, k, v))
+      );
+
+      switch (sortOption) {
+        case "price_low_high":
+          result.sort((a, b) => a.price - b.price);
+          break;
+        case "price_high_low":
+          result.sort((a, b) => b.price - a.price);
+          break;
+        case "name_asc":
+          result.sort((a, b) => a.name.localeCompare(b.name));
+          break;
+        case "name_desc":
+          result.sort((a, b) => b.name.localeCompare(a.name));
+          break;
+        default:
+          break;
+      }
+
+      const total = result.length;
+      const start = (page - 1) * limit;
+      const paginated = result.slice(start, start + limit);
+
+      resolve({ products: paginated, total });
+    }, 500);
+  });
+};
+
 export const getTotalProductsByFilterKey = (key, productsArray) => {
   return new Promise((resolve) => {
     setTimeout(() => {

--- a/src/index.js
+++ b/src/index.js
@@ -2,14 +2,18 @@ import React from "react";
 import { ChakraProvider, extendTheme } from "@chakra-ui/react";
 import { createRoot } from "react-dom/client"; // Importa createRoot desde react-dom
 import App from "./App";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import theme from "./components/Config/theme";
 
 const customTheme = extendTheme(theme);
+const queryClient = new QueryClient();
 
 createRoot(document.getElementById("root")).render(
   <React.StrictMode>
     <ChakraProvider theme={customTheme}>
-      <App />
+      <QueryClientProvider client={queryClient}>
+        <App />
+      </QueryClientProvider>
     </ChakraProvider>
   </React.StrictMode>
 );

--- a/src/services/productService.js
+++ b/src/services/productService.js
@@ -3,6 +3,7 @@ import {
   getProductById as mockGetProductById,
   getProductsByCategory as mockGetProductsByCategory,
   getProductsByFilters as mockGetProductsByFilters,
+  getProductsPaginated as mockGetProductsPaginated,
   getTotalProductsByFilterKey as mockGetTotalProductsByFilterKey,
   getProductsByFiltersExceptKey as mockGetProductsByFiltersExceptKey,
   FILTER_CONFIG,
@@ -54,6 +55,9 @@ export const getProductsByCategory = (category, opts) =>
 export const getProductsByFilters = (filters, opts) =>
   wrapRequest(() => mockGetProductsByFilters(filters), opts);
 
+export const getProductsPaginated = (params, opts) =>
+  wrapRequest(() => mockGetProductsPaginated(params), opts);
+
 export const getTotalProductsByFilterKey = (key, products, opts) =>
   wrapRequest(() => mockGetTotalProductsByFilterKey(key, products), opts);
 
@@ -65,6 +69,7 @@ export const productService = {
   getProductById,
   getProductsByCategory,
   getProductsByFilters,
+  getProductsPaginated,
   getTotalProductsByFilterKey,
   getProductsByFiltersExceptKey,
   FILTER_CONFIG,


### PR DESCRIPTION
## Summary
- switch to React Query for products hook
- enable local caching and pagination
- sync filters and page via URL
- show page skeleton while loading
- document new behaviour

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c8dd628b88322bf9d050e1bda316d