### PR TITLE
Separate cart and wishlist contexts

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -4,6 +4,7 @@ import ItemListContainer from "./components/ItemListContainer/ItemListContainer"
 import ItemDetailContainer from "./components/ItemDetailContainer/ItemDetailContainer";
 import Cart from "./components/Cart/Cart";
 import { CartProvider } from "./components/CartContext/CartContext";
+import { WishlistProvider } from "./components/WishlistContext/WishlistContext";
 import NotFound from "./components/NotFound/NotFound";
 import Layout from "./components/Layout/Layout";
 import Wishlist from "./components/Wishlist/Wishlist";
@@ -14,7 +15,9 @@ function AppWrapper() {
   return (
     <BrowserRouter>
       <CartProvider>
-        <AppContent />
+        <WishlistProvider>
+          <AppContent />
+        </WishlistProvider>
       </CartProvider>
     </BrowserRouter>
   );

--- a/src/components/CartContext/CartContext.test.js
+++ b/src/components/CartContext/CartContext.test.js
@@ -11,4 +11,35 @@ test('adds item to cart', () => {
   });
   expect(result.current.cart).toHaveLength(1);
   expect(result.current.cart[0].quantity).toBe(2);
+  expect(result.current.totalQuantity).toBe(2);
+  expect(result.current.totalPrice).toBe(20);
+  expect(result.current.isInCart('1')).toBe(true);
+});
+
+test('updates item quantity', () => {
+  const { result } = renderHook(() => React.useContext(CartContext), { wrapper });
+  act(() => {
+    result.current.addItem({ id: '1', name: 'Test', price: 10 }, 1);
+    result.current.increaseQuantity('1');
+    result.current.decreaseQuantity('1');
+  });
+  expect(result.current.cart[0].quantity).toBe(1);
+});
+
+test('removes item from cart', () => {
+  const { result } = renderHook(() => React.useContext(CartContext), { wrapper });
+  act(() => {
+    result.current.addItem({ id: '1', name: 'Test', price: 10 }, 1);
+    result.current.removeItem('1');
+  });
+  expect(result.current.cart).toHaveLength(0);
+});
+
+test('clears cart', () => {
+  const { result } = renderHook(() => React.useContext(CartContext), { wrapper });
+  act(() => {
+    result.current.addItem({ id: '1', name: 'Test', price: 10 }, 1);
+    result.current.clearCart();
+  });
+  expect(result.current.cart).toHaveLength(0);
 });

--- a/src/components/ItemDetail/ItemDetail.jsx
+++ b/src/components/ItemDetail/ItemDetail.jsx
@@ -30,15 +30,15 @@ const ItemDetail = ({ product }) => {
     rating,
   } = product;
 
-  const { cart, addItem } = useCart();
-  const { wishlist, addToWishlist, removeFromWishlist } = useWishlist();
+  const { cart, addItem, isInCart } = useCart();
+  const { wishlist, addToWishlist, removeFromWishlist, isInWishlist } = useWishlist();
   const toast = useToast();
 
-  const isInWishlist = wishlist.some((prod) => prod.id === id);
-  const isInCart = cart.some((prod) => prod.id === id);
+  const inWishlist = isInWishlist(id);
+  const inCart = isInCart(id);
 
   const handleAddToCart = () => {
-    if (isInCart) {
+    if (inCart) {
       toast({
         title: "Producto ya en el carrito.",
         description: `${name} ya estaba en tu carrito.`,
@@ -61,7 +61,7 @@ const ItemDetail = ({ product }) => {
   };
 
   const handleToggleWishlist = () => {
-    if (isInWishlist) {
+    if (inWishlist) {
       removeFromWishlist(id);
       toast({
         title: "Removido de favoritos.",
@@ -163,8 +163,8 @@ const ItemDetail = ({ product }) => {
             {name}
           </Heading>
           <IconButton
-            icon={isInWishlist ? <FaHeart /> : <FaRegHeart />}
-            colorScheme={isInWishlist ? "pink" : "gray"}
+            icon={inWishlist ? <FaHeart /> : <FaRegHeart />}
+            colorScheme={inWishlist ? "pink" : "gray"}
             variant="ghost"
             size="lg"
             onClick={handleToggleWishlist}

--- a/src/components/ProductCard/ProductCard.jsx
+++ b/src/components/ProductCard/ProductCard.jsx
@@ -35,20 +35,18 @@ const ProductCard = ({
   isNew,
   isOnSale,
 }) => {
-  const { cart, addItem } = useCart();
-  const { wishlist, addToWishlist, removeFromWishlist } = useWishlist();
+  const { cart, addItem, isInCart } = useCart();
+  const { wishlist, addToWishlist, removeFromWishlist, isInWishlist } = useWishlist();
   const toast = useToast();
   const location = useLocation();
 
-  const isInWishlist = wishlist.some((prod) => prod.id === id);
+  const inWishlist = isInWishlist(id);
 const [activeImage, setActiveImage] = useState(
   images?.[0] || image || img
 );
 
   const handleAddToCart = () => {
-    const isInCart = cart.some((prod) => prod.id === id);
-
-    if (isInCart) {
+    if (isInCart(id)) {
       toast({
         title: "Producto ya en el carrito.",
         description: `${name} ya estaba en tu carrito.`,
@@ -73,7 +71,7 @@ const [activeImage, setActiveImage] = useState(
   };
 
   const handleToggleWishlist = () => {
-    if (isInWishlist) {
+    if (inWishlist) {
       removeFromWishlist(id);
       toast({
         title: "Removido de favoritos.",
@@ -155,8 +153,8 @@ const [activeImage, setActiveImage] = useState(
         <ProductCardBadge isNew={isNew} isOnSale={isOnSale} />
 
         <IconButton
-          icon={isInWishlist ? <FaHeart /> : <FaRegHeart />}
-          colorScheme={isInWishlist ? "pink" : "gray"}
+          icon={inWishlist ? <FaHeart /> : <FaRegHeart />}
+          colorScheme={inWishlist ? "pink" : "gray"}
           variant="ghost"
           size="sm"
           position="absolute"

--- a/src/components/WishlistContext/WishlistContext.jsx
+++ b/src/components/WishlistContext/WishlistContext.jsx
@@ -1,0 +1,32 @@
+import { createContext, useReducer, useMemo, useCallback } from 'react';
+import { wishlistReducer, initialWishlistState } from '../../reducers/wishlistReducer';
+
+export const WishlistContext = createContext();
+
+export const WishlistProvider = ({ children }) => {
+  const [wishlist, dispatch] = useReducer(wishlistReducer, initialWishlistState);
+
+  const totalWishlistQuantity = useMemo(() => wishlist.length, [wishlist]);
+
+  const addToWishlist = useCallback((item) => dispatch({ type: 'ADD_ITEM', payload: item }), []);
+
+  const removeFromWishlist = useCallback((id) => dispatch({ type: 'REMOVE_ITEM', payload: id }), []);
+
+  const clearWishlist = useCallback(() => dispatch({ type: 'CLEAR_WISHLIST' }), []);
+
+  const isInWishlist = useCallback((id) => wishlist.some((item) => item.id === id), [wishlist]);
+
+  const value = useMemo(
+    () => ({
+      wishlist,
+      totalWishlistQuantity,
+      addToWishlist,
+      removeFromWishlist,
+      clearWishlist,
+      isInWishlist,
+    }),
+    [wishlist, totalWishlistQuantity, addToWishlist, removeFromWishlist, clearWishlist, isInWishlist]
+  );
+
+  return <WishlistContext.Provider value={value}>{children}</WishlistContext.Provider>;
+};

--- a/src/components/WishlistContext/WishlistContext.test.js
+++ b/src/components/WishlistContext/WishlistContext.test.js
@@ -1,0 +1,37 @@
+import React from 'react';
+import { renderHook, act } from '@testing-library/react';
+import { WishlistProvider, WishlistContext } from './WishlistContext';
+
+const wrapper = ({ children }) => (
+  <WishlistProvider>{children}</WishlistProvider>
+);
+
+test('adds items to wishlist without duplicates', () => {
+  const { result } = renderHook(() => React.useContext(WishlistContext), { wrapper });
+  act(() => {
+    result.current.addToWishlist({ id: '1', name: 'Test' });
+    result.current.addToWishlist({ id: '1', name: 'Test' });
+  });
+  expect(result.current.wishlist).toHaveLength(1);
+  expect(result.current.totalWishlistQuantity).toBe(1);
+  expect(result.current.isInWishlist('1')).toBe(true);
+});
+
+test('removes item from wishlist', () => {
+  const { result } = renderHook(() => React.useContext(WishlistContext), { wrapper });
+  act(() => {
+    result.current.addToWishlist({ id: '1', name: 'Test' });
+    result.current.removeFromWishlist('1');
+  });
+  expect(result.current.wishlist).toHaveLength(0);
+});
+
+test('clears wishlist', () => {
+  const { result } = renderHook(() => React.useContext(WishlistContext), { wrapper });
+  act(() => {
+    result.current.addToWishlist({ id: '1', name: 'Test' });
+    result.current.clearWishlist();
+  });
+  expect(result.current.wishlist).toHaveLength(0);
+});
+

--- a/src/hooks/useWishlist.js
+++ b/src/hooks/useWishlist.js
@@ -1,5 +1,5 @@
 import { useContext } from 'react';
-import { CartContext } from '../components/CartContext/CartContext';
+import { WishlistContext } from '../components/WishlistContext/WishlistContext';
 
 export default function useWishlist() {
   const {
@@ -9,7 +9,7 @@ export default function useWishlist() {
     removeFromWishlist,
     clearWishlist,
     isInWishlist,
-  } = useContext(CartContext);
+  } = useContext(WishlistContext);
 
   return {
     wishlist,

--- a/src/reducers/cartReducer.js
+++ b/src/reducers/cartReducer.js
@@ -1,0 +1,40 @@
+export const initialCartState = [];
+
+export function cartReducer(state, action) {
+  switch (action.type) {
+    case 'ADD_ITEM': {
+      const { item, quantity } = action.payload;
+      const existing = state.find((i) => i.id === item.id);
+      if (existing) {
+        return state.map((prod) =>
+          prod.id === item.id
+            ? { ...prod, quantity: (Number(prod.quantity) || 0) + quantity }
+            : prod
+        );
+      }
+      return [...state, { ...item, quantity }];
+    }
+    case 'INCREASE_QUANTITY': {
+      const id = action.payload;
+      return state.map((item) =>
+        item.id === id
+          ? { ...item, quantity: Math.max((Number(item.quantity) || 1) + 1, 1) }
+          : item
+      );
+    }
+    case 'DECREASE_QUANTITY': {
+      const id = action.payload;
+      return state.map((item) =>
+        item.id === id
+          ? { ...item, quantity: Math.max((Number(item.quantity) || 1) - 1, 1) }
+          : item
+      );
+    }
+    case 'REMOVE_ITEM':
+      return state.filter((item) => item.id !== action.payload);
+    case 'CLEAR_CART':
+      return [];
+    default:
+      return state;
+  }
+}

--- a/src/reducers/wishlistReducer.js
+++ b/src/reducers/wishlistReducer.js
@@ -1,0 +1,18 @@
+export const initialWishlistState = [];
+
+export function wishlistReducer(state, action) {
+  switch (action.type) {
+    case 'ADD_ITEM': {
+      const item = action.payload;
+      const exists = state.some((i) => i.id === item.id);
+      if (exists) return state;
+      return [...state, item];
+    }
+    case 'REMOVE_ITEM':
+      return state.filter((item) => item.id !== action.payload);
+    case 'CLEAR_WISHLIST':
+      return [];
+    default:
+      return state;
+  }
+}


### PR DESCRIPTION
## Summary
- split cart and wishlist state into dedicated providers using `useReducer`
- add reducers for cart and wishlist
- memoize derived totals and context values
- keep business logic in hooks and reducers
- update components to use the new hooks without duplicating logic
- add tests for cart and wishlist contexts

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684cc97b41888322ad9c83a9abd71c0c